### PR TITLE
logger, seed func, seed inline

### DIFF
--- a/container.go
+++ b/container.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"sort"
 	"strings"
 	"time"
@@ -22,6 +23,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/log"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
@@ -44,6 +46,15 @@ type Config struct {
 
 	// Path to seeding directory. Will ignore if empty.
 	SeedPath string
+
+	// Seed func to run after migrations. Will ignore if empty.
+	SeedFunc func(db *sql.DB, connStr string) error
+
+	// Inline SQL script to run after migrations. Will ignore if empty.
+	SeedInline string
+
+	// Logger for logging the test container's output. Useful for debugging. Default to testcontainer's noopLogger
+	Logger *slog.Logger
 
 	host string
 	port int
@@ -151,6 +162,50 @@ func setup(ctx context.Context, cfg Config) (*Container, error) {
 			return nil, err
 		}
 		fmt.Println("Database seeding complete")
+	}
+
+	if cfg.SeedFunc != nil {
+		err = func() error {
+			dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable", cfg.host, cfg.port, cfg.User, cfg.Password, cfg.Database)
+			db, err := sql.Open("pgx", dsn)
+			if err != nil {
+				return fmt.Errorf("failed to open database connection: %w", err)
+			}
+			defer db.Close()
+			if err = db.Ping(); err != nil {
+				return fmt.Errorf("failed to ping database: %w", err)
+			}
+
+			connStr := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable", cfg.User, cfg.Password, cfg.host, cfg.port, cfg.Database)
+			return cfg.SeedFunc(db, connStr)
+		}()
+		if err != nil {
+			return nil, err
+		}
+		fmt.Println("Database seed func complete")
+	}
+
+	if cfg.SeedInline != "" {
+		fmt.Println("Executing inline seed")
+		err = func() error {
+			dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable", cfg.host, cfg.port, cfg.User, cfg.Password, cfg.Database)
+			db, err := sql.Open("pgx", dsn)
+			if err != nil {
+				return fmt.Errorf("failed to open database connection: %w", err)
+			}
+			defer db.Close()
+			if err = db.Ping(); err != nil {
+				return fmt.Errorf("failed to ping database: %w", err)
+			}
+			if _, err = db.Exec(cfg.SeedInline); err != nil {
+				return err
+			}
+			return nil
+		}()
+		if err != nil {
+			return nil, err
+		}
+		fmt.Println("Database inline seed complete")
 	}
 
 	c, err := pool.Acquire(ctx)
@@ -309,14 +364,27 @@ func setupPostgresTestContainer(ctx context.Context, cfg Config) (testcontainers
 		}).WithStartupTimeout(10 * time.Second),
 	}
 
+	var logger log.Logger
+	if cfg.Logger != nil {
+		logger = &SlogAdapter{logger: cfg.Logger}
+	}
+
 	pgContainer, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
-		//Logger:  log.Default(),
-		Started: true,
+		Logger:           logger,
+		Started:          true,
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	return pgContainer, nil
+}
+
+type SlogAdapter struct {
+	logger *slog.Logger
+}
+
+func (s *SlogAdapter) Printf(format string, v ...any) {
+	s.logger.Info(fmt.Sprintf(format, v))
 }

--- a/container.go
+++ b/container.go
@@ -50,9 +50,6 @@ type Config struct {
 	// Seed func to run after migrations. Will ignore if empty.
 	SeedFunc func(db *sql.DB, connStr string) error
 
-	// Inline SQL script to run after migrations. Will ignore if empty.
-	SeedInline string
-
 	// Logger for logging the test container's output. Useful for debugging. Default to testcontainer's noopLogger
 	Logger *slog.Logger
 
@@ -183,29 +180,6 @@ func setup(ctx context.Context, cfg Config) (*Container, error) {
 			return nil, err
 		}
 		fmt.Println("Database seed func complete")
-	}
-
-	if cfg.SeedInline != "" {
-		fmt.Println("Executing inline seed")
-		err = func() error {
-			dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable", cfg.host, cfg.port, cfg.User, cfg.Password, cfg.Database)
-			db, err := sql.Open("pgx", dsn)
-			if err != nil {
-				return fmt.Errorf("failed to open database connection: %w", err)
-			}
-			defer db.Close()
-			if err = db.Ping(); err != nil {
-				return fmt.Errorf("failed to ping database: %w", err)
-			}
-			if _, err = db.Exec(cfg.SeedInline); err != nil {
-				return err
-			}
-			return nil
-		}()
-		if err != nil {
-			return nil, err
-		}
-		fmt.Println("Database inline seed complete")
 	}
 
 	c, err := pool.Acquire(ctx)


### PR DESCRIPTION
Jag vill kunna seeda mina tester utan att behöva skapa upp filer. Så jag vill lägga till följande i `brrr.Config`. Vad har du för åsikter? :)

```golang
       // Seed func to run after migrations. Will ignore if empty.
	SeedFunc func(db *sql.DB, connStr string) error

	// Inline SQL script to run after migrations. Will ignore if empty.
	SeedInline string

	// Logger for logging the test container's output. Useful for debugging. Default to testcontainer's noopLogger
	Logger *slog.Logger
```



Då kan jag göra antingen ett one off seed som endast lever finns inne i testet,

```golang
container, err := brrr.NewContainer(brrr.Config{
		User:           "postgres",
		Password:       "password",
		Database:       "db",
		Image:          "postgres",
		MigrationsPath: "./../../../../../../../../../db-migrator/db/",
		SeedInline: `
			sql.....
		`,
		...
```

eller seeda via kod som nedan. Genom att passa connection stringen så kan jag använda MFNs vanliga DB-lib vilket gör det rätt tacksamt att jobba med. 

```golang
container, err := brrr.NewContainer(brrr.Config{
		User:           "postgres",
		Password:       "password",
		Database:       "db",
		Image:          "postgres",
		MigrationsPath: "./../../../../../../../../../db-migrator/db/",
		SeedFunc: func(_ *sql.DB, connStr string) error {
			db, err := dbx.New(connStr)
			if err != nil {
				return err
			}
			defer db.Close()
			user := User{
				...
			}
			return db.Exec(context.Background(),
				sql...,
				user,
			)
		},
		...
```
